### PR TITLE
Use the latest redis-stack with VSS support

### DIFF
--- a/notebooks/redis.ipynb
+++ b/notebooks/redis.ipynb
@@ -132,8 +132,9 @@
     "IN_COLAB = 'google.colab' in sys.modules\n",
     "\n",
     "if IN_COLAB:\n",
-    "    !pip install redis-server\n",
-    "    !/usr/local/lib/python*/dist-packages/redis_server/bin/redis-server --daemonize yes\n",
+    "    !curl -fsSL https://packages.redis.io/redis-stack/redis-stack-server-6.2.6-v7.focal.x86_64.tar.gz -o redis-stack-server.tar.gz",
+    "    !tar -xvf redis-stack-server.tar.gz",
+    "    !./redis-stack-server-6.2.6-v7/bin/redis-stack-server --daemonize yes",
     "else:\n",
     "    !redis-server --daemonize yes"
    ]


### PR DESCRIPTION
The used Python package hasn't been updated for three years now. Modern Redis Stack package supports [VSS](https://redis.io/docs/stack/search/reference/vectors/) and other features that simplify ML, AI and data processing tasks in Python.