### PR TITLE
Fix typo in hashmap.ipynb

### DIFF
--- a/notebooks/hashmap.ipynb
+++ b/notebooks/hashmap.ipynb
@@ -263,7 +263,7 @@
     "class BetterMap:\n",
     "\n",
     "    def __init__(self, n=100):\n",
-    "        self.maps = [LinearMap() for i in range(100)]\n",
+    "        self.maps = [LinearMap() for i in range(n)]\n",
     "\n",
     "    def find_map(self, k):\n",
     "        index = hash(k) % len(self.maps)\n",


### PR DESCRIPTION
Make the init method use the argument instead of the default value